### PR TITLE
Update articles based on selected country

### DIFF
--- a/lib/components/map_view.dart
+++ b/lib/components/map_view.dart
@@ -34,16 +34,11 @@ class _MapViewState extends State<MapView> {
       markers: _marker,
       onTap: (latlng) async {
         List<Placemark> newPlace = await placemarkFromCoordinates(latlng.latitude, latlng.longitude);
-        String country = newPlace[0].country ?? "Unknown Country";
+        currCountry = newPlace[0].country ?? "Unknown Country";
 
-        // If country is same as current country, do nothing
-        // If country is "Unknown Country"; continue and notify error to user
-        if (country == "Unknown Country" || country != currCountry) {
-          if (_marker.isNotEmpty) {
-            _marker.clear();
-          }
+        if (_marker.isNotEmpty) {
+          _marker.clear();
         }
-        currCountry = country;
         
         _onAddMarkerButtonPressed(latlng);
       }

--- a/lib/screens/explore/explore.dart
+++ b/lib/screens/explore/explore.dart
@@ -93,6 +93,37 @@ class _ExploreWidgetState extends State<ExploreWidget> {
     });
   }
 
+  Widget buildHeaderForList() {
+    return IgnorePointer(
+      child: Column (
+        children: [
+          Container(
+              width: 32.0,
+              height: 5.0,
+              margin: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 0),
+              decoration: BoxDecoration(
+                color: Colors.grey[300],
+                borderRadius: BorderRadius.circular(5.0),
+              )
+          ),
+          Row(
+            children: [
+              Text(
+                  "Trending in ${location.toTitleCase()}",
+                  textAlign: TextAlign.start,
+                  style: const TextStyle(
+                    fontWeight: FontWeight.w800,
+                    fontSize: 20,
+                  )
+              )
+            ],
+          ),
+          const SizedBox(height: 16.0,),
+        ],
+      ),
+    );
+  }
+
   Widget buildBottomSheet() {
     return DraggableScrollableSheet(
         initialChildSize: 0.3,
@@ -113,38 +144,16 @@ class _ExploreWidgetState extends State<ExploreWidget> {
             ),
             child: Padding(
               padding: const EdgeInsets.fromLTRB(16.0, 0.0, 16.0, 0.0),
-              child: Column(
+              child: Stack(
                 children: [
-                  Container(
-                      width: 32.0,
-                      height: 5.0,
-                      margin: const EdgeInsets.symmetric(vertical: 12.0, horizontal: 0),
-                      decoration: BoxDecoration(
-                        color: Colors.grey[300],
-                        borderRadius: BorderRadius.circular(5.0),
-                      )
-                  ),
-                  Row(
-                    children: [
-                      Text(
-                          "Trending in ${location.toTitleCase()}",
-                          textAlign: TextAlign.start,
-                          style: const TextStyle(
-                            fontWeight: FontWeight.w800,
-                            fontSize: 20,
-                          )
-                      )
-                    ],
-                  ),
-                  const SizedBox(height: 16.0),
-                  Expanded(
-                    flex: 1,
-                    child: ListView.separated(
+                    ListView.separated(
                         itemCount: articles.length,
                         controller: scrollController,
-                        itemBuilder: articleItemBuilder,
+                        itemBuilder: (BuildContext context, int index) {
+                          return index == 0 ? buildHeaderForList()
+                            : articleItemBuilder(context, index - 1);
+                        },
                         separatorBuilder: (BuildContext context, int index) => const Divider(height: 8.0)
-                    ),
                   ),
                 ],
               ),
@@ -154,11 +163,26 @@ class _ExploreWidgetState extends State<ExploreWidget> {
     );
   }
 
+  updateLocation(String country) {
+    // Skip if country already loaded
+    if (location == country) { return; }
+
+    location = country;
+
+    NewsAPI(location: location)
+        .getData()
+        .then((data) {
+      setState(() {
+        articles = data;
+      });
+    });
+  }
+
   @override
   Widget build(BuildContext context) {
     return Stack(
       children: [
-        MapView(),
+        MapView(updateCountry: updateLocation,),
         SafeArea(
             child: buildBottomSheet()
         ),


### PR DESCRIPTION
The PR addresses a few issues, with the main one updating the articles based on the country selected. A more comprehensive list is below:

* Users can see articles from the country they tap on
* Fixed ScrollableSheet issue that prevented users from dragging the header upwards
* Made the header of ScrollableSheet expandable as needed (ie. expand on different accessibility font sizes)
* When the user taps on the same country multiple times, the app does not call News API wastefully

There are still some issues when tapping on the ocean. Need better error handling for this use case. Sometimes the address is valid and the country field is empty while other times the geocoder throws an error to the console.

Also, some long country names, such as the "Democratic Republic of Congo" overflow the article view header. Need to allow "Trending ..." text to wrap around.

Adding both issues to the HackMD tracker.

Resolves #1 