### PR TITLE
Add explore recommendations

### DIFF
--- a/lib/components/map_view.dart
+++ b/lib/components/map_view.dart
@@ -1,7 +1,9 @@
 import 'dart:async';
 import 'package:flutter/material.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:geocoding/geocoding.dart';
 import 'package:google_maps_flutter/google_maps_flutter.dart';
+import 'package:mappu/main.dart';
 
 class MapView extends StatefulWidget {
   final Function updateCountry;
@@ -16,6 +18,7 @@ class _MapViewState extends State<MapView> {
   final Completer<GoogleMapController> _controller = Completer();
   final Set<Marker> _marker = {};
 
+  late FToast fToast;
   String currCountry = "";
 
   static const CameraPosition _initialPosition = CameraPosition(
@@ -24,24 +27,39 @@ class _MapViewState extends State<MapView> {
   );
 
   @override
+  void initState() {
+    fToast = FToast();
+    fToast.init(globalKey.currentState!.context);
+  }
+
+  @override
   Widget build(BuildContext context) {
     return GoogleMap(
-      mapType: MapType.normal,
-      initialCameraPosition: _initialPosition,
-      onMapCreated: (GoogleMapController controller) {
-        _controller.complete(controller);
-      },
-      markers: _marker,
-      onTap: (latlng) async {
-        List<Placemark> newPlace = await placemarkFromCoordinates(latlng.latitude, latlng.longitude);
-        currCountry = newPlace[0].country ?? "Unknown Country";
+        mapType: MapType.normal,
+        initialCameraPosition: _initialPosition,
+        onMapCreated: (GoogleMapController controller) {
+          _controller.complete(controller);
+        },
+        markers: _marker,
+        onTap: (latlng) async {
+          try {
+            List<Placemark> newPlace = await placemarkFromCoordinates(
+                latlng.latitude, latlng.longitude);
+            if (newPlace[0].country == null || newPlace[0].country!.isEmpty) {
+              throw Exception();
+            }
 
-        if (_marker.isNotEmpty) {
-          _marker.clear();
+            currCountry = newPlace[0].country ?? "Unknown Country";
+
+            if (_marker.isNotEmpty) {
+              _marker.clear();
+            }
+
+            _onAddMarkerButtonPressed(latlng);
+          } catch (err) {
+            _showToast();
+          }
         }
-        
-        _onAddMarkerButtonPressed(latlng);
-      }
     );
   }
 
@@ -60,7 +78,8 @@ class _MapViewState extends State<MapView> {
         onTap: () {
           setState(() {
             _marker.clear();
-            currCountry = "";
+            currCountry = "Unknown Country";
+            widget.updateCountry(currCountry);
           });
         }
       ));
@@ -75,5 +94,34 @@ class _MapViewState extends State<MapView> {
     });
 
     widget.updateCountry(currCountry);
+  }
+
+  _showToast() {
+    Widget toast = Container(
+      padding: const EdgeInsets.symmetric(horizontal: 24.0, vertical: 12.0),
+      decoration: BoxDecoration(
+        borderRadius: BorderRadius.circular(25.0),
+        color: Colors.redAccent,
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: const [
+          Icon(Icons.block, color: Colors.white,),
+          SizedBox(
+            width: 12.0,
+          ),
+          Text("Invalid Country",
+            style: TextStyle(
+              color: Colors.white,
+            ),),
+        ],
+      ),
+    );
+
+    fToast.showToast(
+      child: toast,
+      gravity: ToastGravity.BOTTOM,
+      toastDuration: Duration(seconds: 2),
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -4,6 +4,8 @@ import 'screens/saved/saved.dart';
 import 'screens/passport/passport.dart';
 import 'package:flutter_config/flutter_config.dart';
 
+GlobalKey globalKey = GlobalKey();
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized(); // Required by FlutterConfig
   await FlutterConfig.loadEnvVariables(); // Load .env which includes API keys
@@ -30,6 +32,7 @@ class _HomeState extends State<Home> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
+      key: globalKey,
       body: _children[_currentIndex],
       bottomNavigationBar: BottomNavigationBar(
         onTap: onTabTapped,

--- a/lib/screens/explore/explore.dart
+++ b/lib/screens/explore/explore.dart
@@ -21,7 +21,7 @@ class _ExploreWidgetState extends State<ExploreWidget> {
   final FloatingSearchBarController searchBarController = FloatingSearchBarController();
 
   List<NewsArticle> articles = <NewsArticle>[];
-  String location = "Japan";
+  String location = "Unknown Country";
 
   Widget articleItemBuilder(context, index) {
     return Padding(
@@ -108,12 +108,23 @@ class _ExploreWidgetState extends State<ExploreWidget> {
           ),
           Row(
             children: [
-              Text(
-                  "Trending in ${location.toTitleCase()}",
+              location == "Unknown Country" ? const Text(
+                  "Explore Recommendations",
                   textAlign: TextAlign.start,
-                  style: const TextStyle(
+                  style: TextStyle(
                     fontWeight: FontWeight.w800,
                     fontSize: 20,
+                  )
+              )
+              : Flexible(
+                  child: Text(
+                      "Trending in ${location.toTitleCase()}",
+                      textAlign: TextAlign.start,
+                      style: const TextStyle(
+                        fontWeight: FontWeight.w800,
+                        fontSize: 20,
+                      ),
+                      overflow: TextOverflow.ellipsis,
                   )
               )
             ],

--- a/lib/services/news_api.dart
+++ b/lib/services/news_api.dart
@@ -12,7 +12,7 @@ class NewsAPI {
     List<NewsArticle> articles = <NewsArticle>[];
     try {
 
-      Response response = await get(Uri.parse('https://news.google.com/rss/headlines/section/geo/$location'));
+      Response response = await getArticles();
       final document = XmlDocument.parse(response.body);
       // print(document);
       final items = document.findAllElements('item');
@@ -41,6 +41,14 @@ class NewsAPI {
     } catch (e) {
       print("Caught error: $e");
       return articles;
+    }
+  }
+
+  Future<Response> getArticles() async {
+    if (location == "Unknown Country") {
+      return get(Uri.parse('https://news.google.com/rss/topics/CAAqJggKIiBDQkFTRWdvSUwyMHZNRGx1YlY4U0FtVnVHZ0pWVXlnQVAB?hl=en-US&gl=US&ceid=US:en'));
+    } else {
+      return get(Uri.parse('https://news.google.com/rss/headlines/section/geo/$location'));
     }
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -95,6 +95,18 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  fluttertoast:
+    dependency: "direct main"
+    description:
+      name: fluttertoast
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "8.0.8"
   geocoding:
     dependency: "direct main"
     description:
@@ -137,6 +149,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.0.0"
+  js:
+    dependency: transitive
+    description:
+      name: js
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.6.3"
   lints:
     dependency: transitive
     description:
@@ -150,7 +169,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   material_floating_search_bar:
     dependency: "direct main"
     description:
@@ -260,7 +279,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timeago:
     dependency: "direct main"
     description:
@@ -281,7 +300,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   xml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -34,16 +34,18 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.2
-  http: ^0.13.4
-  xml: ^5.3.1
-  flutter_inappwebview: ^5.3.2
-  timeago: ^3.1.0
-  material_floating_search_bar: ^0.3.6
-  google_maps_flutter: ^2.1.0
-  geocoding: ^2.0.1
+
   flutter_config: ^2.0.0
-  sqflite: ^2.0.0+4
+  flutter_inappwebview: ^5.3.2
+  fluttertoast: ^8.0.8
+  geocoding: ^2.0.1
+  google_maps_flutter: ^2.1.0
+  http: ^0.13.4
+  material_floating_search_bar: ^0.3.6
   path: ^1.8.0
+  sqflite: ^2.0.0+4
+  timeago: ^3.1.0
+  xml: ^5.3.1
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR focuses on adding an 'Explore Recommendations' page to the app when no country is selected. A detailed list of issues/features in this PR:
* Added an Explore Recommendations page that pulls from the World news section
* When a user has no country selected or when the app is opened by default, explore recommendations is shown
* If a user taps on the ocean, a Toast shows up at the bottom of the app, alerting the user of "Invalid Country."
* Long country names like the Democratic Republic of Congo now add ellipses at the end of the screen in the Trending title

Closes #3 