### PR TITLE
Show help text for saving articles

### DIFF
--- a/lib/components/articles_sheet.dart
+++ b/lib/components/articles_sheet.dart
@@ -7,6 +7,7 @@ import 'package:mappu/models/read_article.dart';
 import 'package:mappu/models/saved_article.dart';
 import 'package:mappu/models/news_article.dart';
 import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:showcaseview/showcaseview.dart';
 import 'package:timeago/timeago.dart' as timeago;
 
 class ArticlesSheet extends StatelessWidget {
@@ -14,12 +15,14 @@ class ArticlesSheet extends StatelessWidget {
     required this.browser,
     required this.articles,
     required this.location,
-    required this.showToast}) : super(key: key);
+    required this.showToast,
+    required this.articleKey,}) : super(key: key);
 
   final ChromeSafariBrowser browser;
   final List<NewsArticle> articles;
   final String location;
   final Function showToast;
+  final GlobalKey articleKey;
   final dbHelper = DatabaseHelper.instance;
 
   _saveArticle(NewsArticle article, String location) {
@@ -30,7 +33,7 @@ class ArticlesSheet extends StatelessWidget {
     showToast(Colors.grey, Icons.bookmark_border, "Saved");
   }
 
-  Widget articleItemBuilder(context, index) {
+  Widget buildItem(index) {
     return Padding(
         padding: const EdgeInsets.fromLTRB(0, 4.0, 4.0, 4.0),
         child: Slidable(
@@ -64,45 +67,53 @@ class ArticlesSheet extends StatelessWidget {
                 color: Colors.white,
               ),
               child:
-                Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    Text(
-                        articles[index].source,
-                        style: TextStyle(
-                          fontSize: 12.0,
-                          color: Colors.grey[700],
-                          fontWeight: FontWeight.w500,
-                        )
-                    ),
-                    const SizedBox(height: 3.0),
-                    Text(
-                        articles[index].title,
-                        style: const TextStyle(
-                          fontSize: 18.0,
-                          fontWeight: FontWeight.w500,
-                          letterSpacing: -0.5,
-                        )
-                    ),
-                    const SizedBox(height: 24.0),
-                    Row(
-                      mainAxisAlignment: MainAxisAlignment.start,
-                      children: [
-                        Text(
-                            timeago.format(articles[index].pubDate),
-                            style: TextStyle(
-                              fontSize: 10.0,
-                              color: Colors.grey[500],
-                            )
-                        ),
-                      ],
-                    )
-                  ],
-                ),
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Text(
+                      articles[index].source,
+                      style: TextStyle(
+                        fontSize: 12.0,
+                        color: Colors.grey[700],
+                        fontWeight: FontWeight.w500,
+                      )
+                  ),
+                  const SizedBox(height: 3.0),
+                  Text(
+                      articles[index].title,
+                      style: const TextStyle(
+                        fontSize: 18.0,
+                        fontWeight: FontWeight.w500,
+                        letterSpacing: -0.5,
+                      )
+                  ),
+                  const SizedBox(height: 24.0),
+                  Row(
+                    mainAxisAlignment: MainAxisAlignment.start,
+                    children: [
+                      Text(
+                          timeago.format(articles[index].pubDate),
+                          style: TextStyle(
+                            fontSize: 10.0,
+                            color: Colors.grey[500],
+                          )
+                      ),
+                    ],
+                  )
+                ],
+              ),
+            ),
           ),
-        ),
-      )
+        )
     );
+  }
+
+  Widget articleItemBuilder(context, index) {
+    return index == 0 ? Showcase(
+        key: articleKey,
+        child: buildItem(index),
+        description: 'Save article by sliding left and tapping on save icon') :
+      buildItem(index);
   }
 
   Widget buildHeaderForList() {

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:showcaseview/showcaseview.dart';
 import 'screens/explore/explore.dart';
 import 'screens/saved/saved.dart';
 import 'screens/passport/passport.dart';
@@ -33,7 +34,9 @@ class _HomeState extends State<Home> {
   Widget build(BuildContext context) {
     return Scaffold(
       key: globalKey,
-      body: _children[_currentIndex],
+      body: ShowCaseWidget(
+          builder: Builder(builder: (context) => _children[_currentIndex],)
+      ),
       bottomNavigationBar: BottomNavigationBar(
         onTap: onTabTapped,
         currentIndex: _currentIndex,

--- a/lib/screens/explore/explore.dart
+++ b/lib/screens/explore/explore.dart
@@ -10,11 +10,13 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 import 'package:mappu/components/map_view.dart';
 import 'package:mappu/main.dart';
+import 'package:shared_preferences/shared_preferences.dart';
 import 'package:showcaseview/showcaseview.dart';
 
 const NO_LAT_LNG = LatLng(90, 91);
 
 class ExploreWidget extends StatefulWidget {
+  static const prefIsFirstLaunch = "PREFERENCES_IS_FIRST_LAUNCH_STRING";
   const ExploreWidget({Key? key}) : super(key: key);
 
   @override
@@ -49,9 +51,24 @@ class _ExploreWidgetState extends State<ExploreWidget> {
     fToast = FToast();
     fToast.init(globalKey.currentState!.context);
 
-    WidgetsBinding.instance!.addPostFrameCallback((_) =>
-        ShowCaseWidget.of(context)!.startShowCase([_one])
-    );
+    WidgetsBinding.instance!.addPostFrameCallback((_) {
+      _isFirstLaunch().then((result) {
+        if (result) {
+          ShowCaseWidget.of(context)!.startShowCase([_one]);
+        }
+      });
+    });
+  }
+
+  Future<bool> _isFirstLaunch() async{
+    final sharedPreferences = await SharedPreferences.getInstance();
+    bool isFirstLaunch = sharedPreferences.getBool(ExploreWidget.prefIsFirstLaunch) ?? true;
+
+    if(isFirstLaunch) {
+      sharedPreferences.setBool(ExploreWidget.prefIsFirstLaunch, false);
+    }
+
+    return isFirstLaunch;
   }
 
   updateLocation(String country, LatLng newLatLng) {

--- a/lib/screens/explore/explore.dart
+++ b/lib/screens/explore/explore.dart
@@ -10,6 +10,7 @@ import 'package:flutter_inappwebview/flutter_inappwebview.dart';
 import 'package:material_floating_search_bar/material_floating_search_bar.dart';
 import 'package:mappu/components/map_view.dart';
 import 'package:mappu/main.dart';
+import 'package:showcaseview/showcaseview.dart';
 
 const NO_LAT_LNG = LatLng(90, 91);
 
@@ -21,6 +22,8 @@ class ExploreWidget extends StatefulWidget {
 }
 
 class _ExploreWidgetState extends State<ExploreWidget> {
+  GlobalKey _one = GlobalKey();
+
   final ChromeSafariBrowser browser = ArticleReader();
   final FloatingSearchBarController searchBarController = FloatingSearchBarController();
 
@@ -45,6 +48,10 @@ class _ExploreWidgetState extends State<ExploreWidget> {
 
     fToast = FToast();
     fToast.init(globalKey.currentState!.context);
+
+    WidgetsBinding.instance!.addPostFrameCallback((_) =>
+        ShowCaseWidget.of(context)!.startShowCase([_one])
+    );
   }
 
   updateLocation(String country, LatLng newLatLng) {
@@ -107,7 +114,9 @@ class _ExploreWidgetState extends State<ExploreWidget> {
             child: ArticlesSheet(browser: browser,
               articles: articles,
               location: location,
-              showToast: showToast,)
+              showToast: showToast,
+              articleKey: _one,
+            )
         ),
         SearchBar(
           controller: searchBarController,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.8.1"
+    version: "2.8.2"
   boolean_selector:
     dependency: transitive
     description:
@@ -21,7 +21,7 @@ packages:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   charcode:
     dependency: transitive
     description:
@@ -89,7 +89,7 @@ packages:
       name: flutter_plugin_android_lifecycle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.4"
+    version: "2.0.5"
   flutter_slidable:
     dependency: "direct main"
     description:
@@ -141,7 +141,7 @@ packages:
       name: google_maps_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   google_maps_flutter_platform_interface:
     dependency: transitive
     description:
@@ -183,7 +183,7 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.11"
   material_floating_search_bar:
     dependency: "direct main"
     description:
@@ -219,6 +219,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  showcaseview:
+    dependency: "direct main"
+    description:
+      name: showcaseview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.4"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -293,7 +300,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.2"
+    version: "0.4.3"
   timeago:
     dependency: "direct main"
     description:
@@ -314,7 +321,7 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   xml:
     dependency: "direct main"
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -57,6 +57,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.2.0"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.1.2"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -205,6 +219,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.0"
+  path_provider_linux:
+    dependency: transitive
+    description:
+      name: path_provider_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.2"
+  path_provider_platform_interface:
+    dependency: transitive
+    description:
+      name: path_provider_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  path_provider_windows:
+    dependency: transitive
+    description:
+      name: path_provider_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.4"
   petitparser:
     dependency: transitive
     description:
@@ -212,6 +247,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "4.4.0"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.2"
   plugin_platform_interface:
     dependency: transitive
     description:
@@ -219,6 +261,69 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.0.2"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.2.4"
+  shared_preferences:
+    dependency: "direct main"
+    description:
+      name: shared_preferences
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  shared_preferences_android:
+    dependency: transitive
+    description:
+      name: shared_preferences_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.9"
+  shared_preferences_ios:
+    dependency: transitive
+    description:
+      name: shared_preferences_ios
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.8"
+  shared_preferences_linux:
+    dependency: transitive
+    description:
+      name: shared_preferences_linux
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
+  shared_preferences_macos:
+    dependency: transitive
+    description:
+      name: shared_preferences_macos
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  shared_preferences_platform_interface:
+    dependency: transitive
+    description:
+      name: shared_preferences_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
+  shared_preferences_web:
+    dependency: transitive
+    description:
+      name: shared_preferences_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.2"
+  shared_preferences_windows:
+    dependency: transitive
+    description:
+      name: shared_preferences_windows
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.3"
   showcaseview:
     dependency: "direct main"
     description:
@@ -322,6 +427,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.1"
+  win32:
+    dependency: transitive
+    description:
+      name: win32
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.3.1"
+  xdg_directories:
+    dependency: transitive
+    description:
+      name: xdg_directories
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   xml:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -49,6 +49,7 @@ dependencies:
   xml: ^5.3.1
   flutter_spinkit: ^5.1.0
   showcaseview: ^1.1.4
+  shared_preferences: ^2.0.9
 
 dev_dependencies:
   flutter_test:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -48,6 +48,7 @@ dependencies:
   sqflite: ^2.0.0+4
   xml: ^5.3.1
   flutter_spinkit: ^5.1.0
+  showcaseview: ^1.1.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
The PR adds a help text that tells users how to save articles. The help text is only shown the first time the app is loaded, which is kept track of using the `shared_preferences` library. Unfortunately, there is no way to move the help text to hover on top of the article without heavy customization of the `showcaseview` library.

Closes #26 